### PR TITLE
Add PaymentTab component and integrate into PaymentProvider page:

### DIFF
--- a/app/components/paymentTabs.tsx
+++ b/app/components/paymentTabs.tsx
@@ -1,0 +1,181 @@
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+
+
+export default function PaymentTab() {
+  return (
+    <Tabs defaultValue="tab-1">
+      <ScrollArea>
+        <TabsList className="mb-3">
+          <TabsTrigger value="tab-1">
+            <HouseIcon
+              className="-ms-0.5 me-1.5 opacity-60"
+              size={16}
+              aria-hidden="true"
+            />
+            PolarSh
+          </TabsTrigger>
+          <TabsTrigger value="tab-2" className="group">
+            <PanelsTopLeftIcon
+              className="-ms-0.5 me-1.5 opacity-60"
+              size={16}
+              aria-hidden="true"
+            />
+            Stripe
+            <Badge
+              className="bg-primary/15 ms-1.5 min-w-5 px-1 transition-opacity group-data-[state=inactive]:opacity-50"
+              variant="secondary"
+            >
+              3
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger value="tab-3" className="group">
+            <BoxIcon
+              className="-ms-0.5 me-1.5 opacity-60"
+              size={16}
+              aria-hidden="true"
+            />
+            DodoPayment
+            <Badge className="ms-1.5 transition-opacity group-data-[state=inactive]:opacity-50">
+              New
+            </Badge>
+          </TabsTrigger>
+        </TabsList>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+
+      {/* Tab content 1 */}
+
+      <TabsContent value="tab-1">
+         <div>
+            <Card>
+               <CardHeader>
+                  <div className="flex items-center justify-between mb-4">
+                     <div className="space-y-1">
+                        <CardTitle>Connect Polar</CardTitle>
+                        <CardDescription>Connect with your polar account.</CardDescription>
+                     </div>
+                  </div>
+                  <CardContent>
+                     <form>
+                        <div className="flex flex-col gap-6">
+                           <div className="grid gap-2">
+                              <Label htmlFor="email">Organization id</Label>
+                              
+                              <Input
+                                 id="text"
+                                 type="id"
+                                 placeholder="your-organization-id"
+                                 required
+                              />
+                              <p className="text-xs text-zinc-500">
+                                 Go to your Polar Dashboard {'>'} Setting {'>'} General {'>'} Profile and find "Identifier"
+                              </p>
+                           </div>
+                           <div className="grid gap-2">
+                           {/* <div className="flex items-center">
+                              <Label htmlFor="password">Access Token</Label>
+                              <a
+                                 href="#"
+                                 className="ml-auto inline-block text-sm underline-offset-4 hover:underline"
+                              >
+                                 Forgot your password?
+                              </a>
+                           </div> */}
+                           <Input 
+                              id="password" 
+                              type="password" 
+                              required 
+                              placeholder="polar_pat_********************"
+                           />
+                           <p className="text-xs text-zinc-500">
+                              Go to Settings {'>'} General {'>'} Developer {'>'} Token
+                           </p>
+                           </div>
+                        </div>
+                     </form>
+                     </CardContent>
+                  <Button variant="secondary" className="bg-zinc-800 rounded-lg text-neutral-200 hover:bg-blue-700 font-bold py-2 px-4">
+                     Connect
+                  </Button>  
+               </CardHeader>
+            </Card>
+         </div>
+      </TabsContent>
+
+      {/* Tab content 2 */}
+
+      <TabsContent value="tab-2">
+         <div>
+            <Card>
+               <CardHeader>
+                  <div className="flex items-center justify-between mb-4">
+                     <div className="space-y-1">
+                        <CardTitle>Polar</CardTitle>
+                        <CardDescription>Connect with your polar account.</CardDescription>
+                     </div>
+                     <Button variant="secondary" className="bg-blue-800 text-neutral-200 hover:bg-blue-700 font-bold py-2 px-4 rounded">
+                        Polar Sh
+                     </Button>
+                  </div>
+                  <Separator/>
+                  <div className="flex items-center justify-between mt-4 mb-4">
+                     <div className="space-y-1">
+                        <CardTitle>Stripe</CardTitle>
+                        <CardDescription>Connect with your stripe account.</CardDescription>
+                     </div>
+                     <Button variant="secondary" className="bg-blue-800 text-neutral-200 hover:bg-blue-700 font-bold py-2 px-4 rounded">
+                        Stripe
+                     </Button>
+                  </div>
+                  <Separator/>
+               </CardHeader>
+            </Card>
+         </div>
+      </TabsContent>
+      
+      {/* Tab content 3 */}
+      <TabsContent value="tab-3">
+         <div>
+            <Card>
+               <CardHeader>
+                  <div className="flex items-center justify-between mb-4">
+                     <div className="space-y-1">
+                        <CardTitle>Polar</CardTitle>
+                        <CardDescription>Connect with your polar account.</CardDescription>
+                     </div>
+                     <Button variant="secondary" className="bg-blue-800 text-neutral-200 hover:bg-blue-700 font-bold py-2 px-4 rounded">
+                        Polar Sh
+                     </Button>
+                  </div>
+                  <Separator/>
+                  <div className="flex items-center justify-between mt-4 mb-4">
+                     <div className="space-y-1">
+                        <CardTitle>Stripe</CardTitle>
+                        <CardDescription>Connect with your stripe account.</CardDescription>
+                     </div>
+                     <Button variant="secondary" className="bg-blue-800 text-neutral-200 hover:bg-blue-700 font-bold py-2 px-4 rounded">
+                        Stripe
+                     </Button>
+                  </div>
+                  <Separator/>
+               </CardHeader>
+            </Card>
+         </div>
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/app/dashboard/payment-provider/page.tsx
+++ b/app/dashboard/payment-provider/page.tsx
@@ -1,10 +1,16 @@
-import { Button } from "@/components/ui/button";
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
+import BackRedirectButton from "@/app/components/backRedirectButton";
+import PaymentTab from "@/app/components/paymentTabs";
 
 export default function PaymentProvider(){
    return(
       <main className="relative mx-2 mb-10 mt-4 space-y-8 overflow-hidden px-1 sm:mx-3 md:mx-5 md:mt-5 lg:mx-7 lg:mt-8 xl:mx-10">
+         <div className="mb-4 flex items-center justify-between md:mb-8 lg:mb-12">   
+            <BackRedirectButton
+               href="/dashboard"
+               text="Back to dashboard"
+            />
+         </div>
+         
          <header>
             <section className="mb-4 flex items-center justify-between md:mb-8 lg:mb-12">
                <div className="space-y-1">
@@ -15,32 +21,11 @@ export default function PaymentProvider(){
                </div>
             </section>
          </header>
-         <div>
-            <Card>
-               <CardHeader>
-                  <div className="flex items-center justify-between mb-4">
-                     <div className="space-y-1">
-                        <CardTitle>Polar</CardTitle>
-                        <CardDescription>Connect with your polar account.</CardDescription>
-                     </div>
-                     <Button variant="secondary" className="bg-blue-800 text-neutral-200 hover:bg-blue-700 font-bold py-2 px-4 rounded">
-                        Polar Sh
-                     </Button>
-                  </div>
-                  <Separator/>
-                  <div className="flex items-center justify-between mt-4 mb-4">
-                     <div className="space-y-1">
-                        <CardTitle>Stripe</CardTitle>
-                        <CardDescription>Connect with your stripe account.</CardDescription>
-                     </div>
-                     <Button variant="secondary" className="bg-blue-800 text-neutral-200 hover:bg-blue-700 font-bold py-2 px-4 rounded">
-                        Stripe
-                     </Button>
-                  </div>
-                  <Separator/>
-               </CardHeader>
-            </Card>
+         <div className="mb-4 flex items-center justify-center md:mb-8 lg:mb-12">
+            <PaymentTab/>
          </div>
+
+         
       </main>
    )
 }

--- a/components/comp-433.tsx
+++ b/components/comp-433.tsx
@@ -1,0 +1,70 @@
+import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs"
+
+export default function Component() {
+  return (
+    <Tabs defaultValue="tab-1">
+      <ScrollArea>
+        <TabsList className="mb-3">
+          <TabsTrigger value="tab-1">
+            <HouseIcon
+              className="-ms-0.5 me-1.5 opacity-60"
+              size={16}
+              aria-hidden="true"
+            />
+            Overview
+          </TabsTrigger>
+          <TabsTrigger value="tab-2" className="group">
+            <PanelsTopLeftIcon
+              className="-ms-0.5 me-1.5 opacity-60"
+              size={16}
+              aria-hidden="true"
+            />
+            Projects
+            <Badge
+              className="bg-primary/15 ms-1.5 min-w-5 px-1 transition-opacity group-data-[state=inactive]:opacity-50"
+              variant="secondary"
+            >
+              3
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger value="tab-3" className="group">
+            <BoxIcon
+              className="-ms-0.5 me-1.5 opacity-60"
+              size={16}
+              aria-hidden="true"
+            />
+            Packages
+            <Badge className="ms-1.5 transition-opacity group-data-[state=inactive]:opacity-50">
+              New
+            </Badge>
+          </TabsTrigger>
+        </TabsList>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+      <TabsContent value="tab-1">
+        <p className="text-muted-foreground p-4 pt-1 text-center text-xs">
+          Content for Tab 1
+        </p>
+      </TabsContent>
+      <TabsContent value="tab-2">
+        <p className="text-muted-foreground p-4 pt-1 text-center text-xs">
+          Content for Tab 2
+        </p>
+      </TabsContent>
+      <TabsContent value="tab-3">
+        <p className="text-muted-foreground p-4 pt-1 text-center text-xs">
+          Content for Tab 3
+        </p>
+      </TabsContent>
+    </Tabs>
+  )
+}


### PR DESCRIPTION
- Created a new PaymentTab component to manage payment options with tabs for Polar, Stripe, and DodoPayment.
- Integrated PaymentTab into the PaymentProvider page, replacing the previous card layout for a more organized tabbed interface.
- Added necessary imports and adjusted layout for improved user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a tabbed interface for managing payment provider connections, allowing users to switch between "PolarSh," "Stripe," and "DodoPayment" tabs, each with dedicated forms and actions.
  - Added a back navigation button on the payment provider page for easier return to the dashboard.
  - Added a new tabbed component featuring "Overview," "Projects," and "Packages" tabs, each with icons and badges for improved navigation and clarity.

- **Refactor**
  - Streamlined the payment provider connection page by consolidating multiple UI elements into a single, centralized tabbed component for a cleaner and more intuitive layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->